### PR TITLE
Add POST sentiment/analyze

### DIFF
--- a/test/relay_service/endpoint_test.exs
+++ b/test/relay_service/endpoint_test.exs
@@ -40,13 +40,12 @@ defmodule RelayServiceTest do
   end
 
   test "GET /sentiment/analyze" do
-    endpoint =
-      "sentiment/analyze?text=Lorem%20ipsum%20dolor%20sit%20amet%2C%20consectetur%20adipiscing%20elit.%20Phasellus%20mattis%20ipsum%20luctus%2C%20laoreet%20orci%20at%2C%20placerat%20ipsum.%20Praesent%20vitae%20tristique%20magna."
+    endpoint = "sentiment/analyze?text=Lorem%20ipsum%20"
 
     with_mock(RelayService.Sentiment,
       analyze: fn _ ->
         {:ok,
-         "{\"document_tone\":{\"tones\":[]},\"sentences_tone\":[{\"sentence_id\":0,\"text\":\"Lorem ipsum dolor sit amet, consectetur adipiscing elit.\",\"tones\":[]},{\"sentence_id\":1,\"text\":\"Ut fermentum ultrices scelerisque.\",\"tones\":[]},{\"sentence_id\":2,\"text\":\"Mauris fringilla massa sed ante semper placerat.\",\"tones\":[]}]}"}
+         "{\"document_tone\":{\"tones\":[]},\"sentences_tone\":[{\"sentence_id\":0,\"text\":\"Lorem ipsum\",\"tones\":[]}]}"}
       end
     ) do
       conn = conn(:get, endpoint)
@@ -56,7 +55,7 @@ defmodule RelayServiceTest do
       assert conn.status == 200
 
       assert conn.resp_body ==
-               "{\"document_tone\":{\"tones\":[]},\"sentences_tone\":[{\"sentence_id\":0,\"text\":\"Lorem ipsum dolor sit amet, consectetur adipiscing elit.\",\"tones\":[]},{\"sentence_id\":1,\"text\":\"Ut fermentum ultrices scelerisque.\",\"tones\":[]},{\"sentence_id\":2,\"text\":\"Mauris fringilla massa sed ante semper placerat.\",\"tones\":[]}]}"
+               "{\"document_tone\":{\"tones\":[]},\"sentences_tone\":[{\"sentence_id\":0,\"text\":\"Lorem ipsum\",\"tones\":[]}]}"
     end
   end
 

--- a/test/relay_service/sentiment_test.exs
+++ b/test/relay_service/sentiment_test.exs
@@ -12,28 +12,14 @@ defmodule RelayService.SentimentTest do
                                     :ibm_watson_tone_analyzer_key
                                   )
 
-  @joyous_text "I love this time of year! The leaves begin to change, and I enjoy many cups of tea!"
+  @joyous_text "I love this time of year!"
   @joyous_response {:ok,
                     %HTTPoison.Response{
                       body:
-                        "{\"document_tone\":{\"tones\":[{\"score\":0.930452,\"tone_id\":\"joy\",\"tone_name\":\"Joy\"}]},\"sentences_tone\":[{\"sentence_id\":0,\"text\":\"I love this time of year!\",\"tones\":[{\"score\":0.832088,\"tone_id\":\"joy\",\"tone_name\":\"Joy\"}]},{\"sentence_id\":1,\"text\":\"The leaves begin to change, and I enjoy many cups of tea!\",\"tones\":[{\"score\":0.90188,\"tone_id\":\"joy\",\"tone_name\":\"Joy\"}]}]}",
+                        "{\"document_tone\":{\"tones\":[{\"score\":0.930452,\"tone_id\":\"joy\",\"tone_name\":\"Joy\"}]},\"sentences_tone\":[{\"sentence_id\":0,\"text\":\"I love this time of year!\",\"tones\":[{\"score\":0.832088,\"tone_id\":\"joy\",\"tone_name\":\"Joy\"}]}]}",
                       headers: [
-                        {"Date", "Fri, 07 Sep 2018 16:45:10 GMT"},
                         {"Content-Type", "application/json"},
-                        {"Content-Length", "706"},
-                        {"Connection", "keep-alive"},
-                        {"X-Powered-By", "Servlet/3.1"},
-                        {"Access-Control-Allow-Origin", "*"},
-                        {"X-Service-Api-Version", "3.5.6; 2017-09-21"},
-                        {"X-Service-Build-Number", "2018-08-28T05:18:42"},
-                        {"Cache-Control", "no-store"},
-                        {"Pragma", "no-cache"},
-                        {"X-XSS-Protection", "1; mode=block"},
-                        {"X-Content-Type-Options", "nosniff"},
-                        {"Content-Security-Policy", "default-src 'none'"},
-                        {"Content-Language", "en-US"},
-                        {"x-global-transaction-id", "60ab398cd2b2b62fd202939019fa109f"},
-                        {"X-DP-Watson-Tran-ID", "60ab398cd2b2b62fd202939019fa109f"}
+                        {"Content-Length", "706"}
                       ],
                       request_url: "http://localhost",
                       status_code: 200
@@ -43,14 +29,10 @@ defmodule RelayService.SentimentTest do
                      %HTTPoison.Response{
                        body: "{\"code\":401, \"error\": \"Unauthorized\"}",
                        headers: [
-                         {"Date", "Tue, 11 Sep 2018 14:34:29 GMT"},
                          {"Content-Type", "application/json"},
-                         {"Content-Length", "37"},
-                         {"Connection", "keep-alive"},
-                         {"Www-Authenticate", "Basic realm=\"IBM Watson Gateway(Log-in)\""}
+                         {"Content-Length", "37"}
                        ],
-                       request_url:
-                         "https://gateway-wdc.watsonplatform.net/tone-analyzer/api/v3/tone?version=2017-09-21",
+                       request_url: "http://localhost",
                        status_code: 401
                      }}
 
@@ -82,7 +64,7 @@ defmodule RelayService.SentimentTest do
 
   test "analyze/1 returns the result body as json when request is successful" do
     expected_response =
-      "{\"document_tone\":{\"tones\":[{\"score\":0.930452,\"tone_id\":\"joy\",\"tone_name\":\"Joy\"}]},\"sentences_tone\":[{\"sentence_id\":0,\"text\":\"I love this time of year!\",\"tones\":[{\"score\":0.832088,\"tone_id\":\"joy\",\"tone_name\":\"Joy\"}]},{\"sentence_id\":1,\"text\":\"The leaves begin to change, and I enjoy many cups of tea!\",\"tones\":[{\"score\":0.90188,\"tone_id\":\"joy\",\"tone_name\":\"Joy\"}]}]}"
+      "{\"document_tone\":{\"tones\":[{\"score\":0.930452,\"tone_id\":\"joy\",\"tone_name\":\"Joy\"}]},\"sentences_tone\":[{\"sentence_id\":0,\"text\":\"I love this time of year!\",\"tones\":[{\"score\":0.832088,\"tone_id\":\"joy\",\"tone_name\":\"Joy\"}]}]}"
 
     with_mock(HTTPoison, post: fn _url, _body, _headers, _options -> @joyous_response end) do
       {:ok, response} = RelayService.Sentiment.analyze(@joyous_text)


### PR DESCRIPTION
closes #9 closes #7 

# Description
This PR adds an endpoint `POST /sentiment/analyze` which allow for longer documents to be analyzed. Originally, document size was limited by URI size, since text was being sent via a `GET` request query parameters.

 Fortunately, we were already relying on Watson's `POST` endpoint, so this was just a matter of adding the endpoint on our side.